### PR TITLE
make test/0 by default, so can be tested without mounting local dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN cd /TANK \
 	&& mv tank tank-cli /usr/local/bin \
 	&& rm -rf /TANK
 
-RUN mkdir -p /data
+RUN mkdir -p /data/test/0
 WORKDIR /data
 
 CMD ["tank","-p",".","-l",":11011"]


### PR DESCRIPTION
Make a default topic/partition to be able to test tank via docker without mounting local dir.