### PR TITLE
use clang on alpine:edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
-FROM alpine:latest
+FROM alpine:edge
 MAINTAINER Phaistos Networks
 
 RUN apk add --update \
-	    zlib-dev \
-	    make \
-	    g++ \
-	    jemalloc \
-	    && rm -rf /var/cache/apk/*
+  zlib-dev \
+  musl-dev \
+  make \
+  g++ \
+  clang \
+  jemalloc \
+  && rm -rf /var/cache/apk/*
 
 RUN mkdir -p /TANK
 ADD Makefile *.cpp *.h /TANK/


### PR DESCRIPTION
Would not compile with g++ included with alpine, even edge version.
clang does work, but relies on libraries included with g++ installation, so now compiler is a little more bloated, but it's compiled with clang (yay) :)