### PR TITLE
Remove a time check that aborts if the time is before 2016

### DIFF
--- a/Switch/timings.h
+++ b/Switch/timings.h
@@ -172,10 +172,6 @@ namespace Timings
                         {
                                 abort();
                         }
-                        else if (unlikely(tv.tv_sec < 1451982426u))
-                        {
-                                abort();
-                        }
                         else
                                 return ((tv.tv_sec * 1000000000ULL) + (tv.tv_usec * 1000ULL)) / asNanoseconds;
                 }


### PR DESCRIPTION
This removes a check that seems to have been added as a sanity check.
Closes #67